### PR TITLE
Add nuglint run error path tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/dkoosis/lintkit
 
 go 1.25.4
+
+require github.com/stretchr/testify v1.10.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/nuglint/run_behavior_test.go
+++ b/pkg/nuglint/run_behavior_test.go
@@ -1,0 +1,102 @@
+package nuglint_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dkoosis/lintkit/pkg/nuglint"
+	"github.com/dkoosis/lintkit/pkg/sarif"
+)
+
+func TestRun_ProducesExpectedFindings_When_GivenDiverseInputs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		files         map[string]string
+		paths         []string
+		expectErr     bool
+		assertResults func(t *testing.T, results []sarif.Result, path string)
+	}{
+		{
+			name:      "error: missing input path returns error",
+			paths:     []string{"does-not-exist.jsonl"},
+			expectErr: true,
+		},
+		{
+			name: "error: invalid JSON reports parse failure with location",
+			files: map[string]string{
+				"input.jsonl": `not-json
+{"id":"n:trap:valid","k":"trap","r":"problem: leak\nsymptoms: drip\nworkaround: patch","tags":["ops"],"sev":1}
+`,
+			},
+			assertResults: func(t *testing.T, results []sarif.Result, path string) {
+				require.Len(t, results, 1)
+				assert.Equal(t, "nug-json-parse", results[0].RuleID)
+				if assert.Len(t, results[0].Locations, 1) {
+					loc := results[0].Locations[0].PhysicalLocation
+					assert.Equal(t, filepath.ToSlash(path), loc.ArtifactLocation.URI)
+					assert.Equal(t, 1, loc.Region.StartLine)
+				}
+				assert.Contains(t, results[0].Message.Text, "failed to parse JSON")
+			},
+		},
+		{
+			name: "warning: trap without severity is flagged",
+			files: map[string]string{
+				"trap.jsonl": `{"id":"n:trap:missing-sev","k":"trap","r":"problem: leak\nsymptoms: drip\nworkaround: tape","tags":["ops"]}
+`,
+			},
+			assertResults: func(t *testing.T, results []sarif.Result, path string) {
+				require.Len(t, results, 1)
+				assert.Equal(t, "nug-severity-required", results[0].RuleID)
+				if assert.Len(t, results[0].Locations, 1) {
+					loc := results[0].Locations[0].PhysicalLocation
+					assert.Equal(t, filepath.ToSlash(path), loc.ArtifactLocation.URI)
+					assert.Equal(t, 1, loc.Region.StartLine)
+				}
+				assert.Contains(t, results[0].Message.Text, "trap nuggets must include sev")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tempDir := t.TempDir()
+			var targetPath string
+			for name, content := range tc.files {
+				p := filepath.Join(tempDir, name)
+				require.NoError(t, os.WriteFile(p, []byte(content), 0o644))
+				// Use first file as primary path for assertions.
+				if targetPath == "" {
+					targetPath = p
+				}
+			}
+
+			paths := tc.paths
+			if len(paths) == 0 {
+				for name := range tc.files {
+					paths = append(paths, filepath.Join(tempDir, name))
+				}
+			}
+
+			results, err := nuglint.Run(paths)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			if tc.assertResults != nil {
+				tc.assertResults(t, results, targetPath)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add ADR-008-style table-driven tests for nuglint Run covering missing inputs, malformed JSON, and trap severity validation
- add testify dependency to support clearer assertions in nuglint tests

## Testing
- GOTOOLCHAIN=go1.25.4 go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940084421908325a1efdd4446491a6f)